### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/bip32.yml
+++ b/.github/workflows/bip32.yml
@@ -30,8 +30,8 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
@@ -54,8 +54,8 @@ jobs:
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.toolchain }}
           override: true

--- a/.github/workflows/canonical-path.yml
+++ b/.github/workflows/canonical-path.yml
@@ -29,8 +29,8 @@ jobs:
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.toolchain }}
           override: true
@@ -41,8 +41,8 @@ jobs:
   wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: stable
           target: wasm32-unknown-unknown

--- a/.github/workflows/hkd32.yml
+++ b/.github/workflows/hkd32.yml
@@ -29,8 +29,8 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
@@ -53,8 +53,8 @@ jobs:
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.toolchain }}
           override: true

--- a/.github/workflows/iqhttp.yml
+++ b/.github/workflows/iqhttp.yml
@@ -29,8 +29,8 @@ jobs:
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.toolchain }}
           override: true

--- a/.github/workflows/secrecy.yml
+++ b/.github/workflows/secrecy.yml
@@ -29,8 +29,8 @@ jobs:
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.toolchain }}
           override: true
@@ -41,8 +41,8 @@ jobs:
   wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: stable
           target: wasm32-unknown-unknown

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -16,16 +16,16 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: stable
           override: true
           profile: minimal
-      - uses: actions/cache@v1
+      - uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1.2.1
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-audit-v0.15.2
-      - uses: actions-rs/audit-check@v1
+      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/signatory.yml
+++ b/.github/workflows/signatory.yml
@@ -28,8 +28,8 @@ jobs:
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.toolchain }}
           override: true

--- a/.github/workflows/subtle-encoding.yml
+++ b/.github/workflows/subtle-encoding.yml
@@ -29,8 +29,8 @@ jobs:
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.toolchain }}
           override: true
@@ -41,8 +41,8 @@ jobs:
   wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: stable
           target: wasm32-unknown-unknown

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -9,27 +9,27 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: stable
           override: true
           profile: minimal
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: check
 
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: 1.68.0 # MSRV
           components: clippy
           override: true
           profile: minimal
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: clippy
           args: --all --all-features -- -D warnings
@@ -37,14 +37,14 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: stable
           components: rustfmt
           override: true
           profile: minimal
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: fmt
           args: --all -- --check


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v1` -> `actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0`
  - Version: v1.2.0 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/50fbc622fc4ef5163becd7fab6573eac35f8462e

- `actions-rs/toolchain@v1` -> `actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7`
  - Version: v1.0.7 | Latest: v1.0.6 | Release age: 2207d
  - Commit: https://github.com/actions-rs/toolchain/commit/16499b5e05bf2e26879000db0c1d13f7e13fa3af

- `actions/checkout@v2` -> `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0`
  - Version: v2.7.0 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5

- `actions/cache@v1` -> `actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1.2.1`
  - Version: v1.2.1 | Latest: v5.0.4 | Release age: 22d
  - Commit: https://github.com/actions/cache/commit/f5ce41475b483ad7581884324a6eca9f48f8dcc7

- `actions-rs/audit-check@v1` -> `actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0`
  - Version: v1.2.0 | Latest: v1.2.0 | Release age: 2163d
  - Commit: https://github.com/actions-rs/audit-check/commit/35b7b53b1e25b55642157ac01b4adceb5b9ebef3

- `actions-rs/cargo@v1` -> `actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3`
  - Version: v1.0.3 | Latest: v1.0.1 | Release age: 2398d
  - Commit: https://github.com/actions-rs/cargo/commit/844f36862e911db73fe0815f00a4a2602c279505


### Files modified

- `.github/workflows/bip32.yml`
- `.github/workflows/canonical-path.yml`
- `.github/workflows/hkd32.yml`
- `.github/workflows/iqhttp.yml`
- `.github/workflows/secrecy.yml`
- `.github/workflows/security_audit.yml`
- `.github/workflows/signatory.yml`
- `.github/workflows/subtle-encoding.yml`
- `.github/workflows/workspace.yml`